### PR TITLE
Add retry and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache Airflow Plugin for Microsoft Fabric Plugin. 🚀
 
 ## Introduction
-A Python package that helps Data and Analytics engineers trigger run on demand job items of [Microsoft Fabric](https://www.microsoft.com/en-us/microsoft-fabric) in Apache Airflow DAGs. 
+A Python package that helps Data and Analytics engineers trigger run on demand job items of [Microsoft Fabric](https://www.microsoft.com/en-us/microsoft-fabric) in Apache Airflow DAGs.
 
 [Microsoft Fabric](https://www.microsoft.com/microsoft-fabric) is an end-to-end analytics and data platform designed for enterprises that require a unified solution. It encompasses data movement, processing, ingestion, transformation, real-time event routing, and report building. It offers a comprehensive suite of services including Data Engineering, Data Factory, Data Science, Real-Time Analytics, Data Warehouse, and Databases.
 
@@ -10,7 +10,7 @@ A Python package that helps Data and Analytics engineers trigger run on demand j
 ### Prerequisities
 Before diving in,
 * The plugin supports the <strong>authentication using user tokens</strong>. Tenant level admin account must enable the setting <strong>Allow user consent for apps</strong>. Refer to: [Configure user consent](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent?pivots=portal)
-* Create a Microsoft Entra Id app if you don’t have one. Refer to: Doc 
+* Create a Microsoft Entra Id app if you don’t have one. Refer to: Doc
 * You must have [Refresh token](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#refresh-the-access-token).
 
 
@@ -20,7 +20,8 @@ Since custom connection forms aren't feasible in Apache Airflow plugins, use can
 3. `Login`: The Client ID of your service principal.
 4. `Password`: The refresh token fetched using Microsoft OAuth.
 5. `Extra`: {
-    "tenantId": The Tenant Id of your service principal.
+    "tenantId": The Tenant Id of your service principal,
+    "clientSecret": (optional) The Client Secret for your Entra ID App
 }
 
 ## Operators
@@ -31,15 +32,18 @@ This operator composes the logic for this plugin. It triggers the Fabric item ru
 * `item_id`: The Item Id. i.e Notebook and Pipeline.
 * `fabric_conn_id`: Connection Id for Fabric.
 * `job_type`: "RunNotebook" or "Pipeline".
-* `wait_for_termination`: (Default value: True) Wait until the run item. 
-* `timeout`: Time in seconds to wait for the pipeline or notebook. Used only if `wait_for_termination` is True.
-* `check_interval`: Boolean. Number of seconds to wait before rechecking the refresh status.
+* `wait_for_termination`: (Default value: True) Wait until the run item.
+* `timeout`: int (Default value: 60 * 60 * 24 * 7). Time in seconds to wait for the pipeline or notebook. Used only if `wait_for_termination` is True.
+* `check_interval`: int (Default value: 60s). Time in seconds to wait before rechecking the refresh status.
+* `max_retries`: int (Default value: 5 retries). Max number of times to poll the API for a valid response after starting a job.
+* `retry_delay`: int (Default value: 1s). Polling retry delay.
 * `deferrable`: Boolean. Use the operator in deferrable mode.
+* `job_params`: Dict. Parameters to pass into the job.
 
 ## Features
 * #### Refresh token rotation:
-  Refresh token rotation is a security mechanism that involves replacing the refresh token each time it is used to obtain a new access token. 
-  This process enhances security by reducing the risk of stolen tokens being reused indefinitely. 
+  Refresh token rotation is a security mechanism that involves replacing the refresh token each time it is used to obtain a new access token.
+  This process enhances security by reducing the risk of stolen tokens being reused indefinitely.
 
 * #### Xcom Integration:
   The Fabric run item enriches the Xcom with essential fields for downstream tasks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apache_airflow_microsoft_fabric_plugin"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name="Ambika Garg", email="ambikagarg1101@gmail.com" },
 ]

--- a/src/apache_airflow_microsoft_fabric_plugin/operators/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/operators/fabric.py
@@ -218,13 +218,8 @@ class FabricRunItemOperator(BaseOperator):
 
         Relies on trigger to throw an exception, otherwise it assumes execution was successful.
         """
-        """
-        Return immediately - callback for when the trigger fires.
-
-        Relies on trigger to throw an exception, otherwise it assumes execution was successful.
-        """
         if event:
+            self.log.info(event["message"])
+            context["ti"].xcom_push(key="run_status", value=event["item_run_status"])
             if event["status"] == "error":
                 raise AirflowException(event["message"])
-            self.log.info(event["message"])
-            context["ti"].xcom_push(key="run_status", value=event["status"])

--- a/src/apache_airflow_microsoft_fabric_plugin/triggers/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/triggers/fabric.py
@@ -63,24 +63,24 @@ class FabricTrigger(BaseTrigger):
                         workspace_id=self.workspace_id,
                         item_id=self.item_id,
                     )
-                    item_run_staus = item_run_details["status"]
-                    if item_run_staus == FabricRunItemStatus.COMPLETED:
+                    item_run_status = item_run_details["status"]
+                    if item_run_status == FabricRunItemStatus.COMPLETED:
                         yield TriggerEvent(
                             {
                                 "status": "success",
-                                "message": f"The item run {self.item_run_id} has status {item_run_staus}.",
+                                "message": f"The item run {self.item_run_id} has status {item_run_status}.",
                                 "run_id": self.item_run_id,
-                                "item_run_status": item_run_staus,
+                                "item_run_status": item_run_status,
                             }
                         )
                         return
-                    elif item_run_staus in FabricRunItemStatus.FAILURE_STATES:
+                    elif item_run_status in FabricRunItemStatus.FAILURE_STATES:
                         yield TriggerEvent(
                             {
                                 "status": "error",
-                                "message": f"The item run {self.item_run_id} has status {item_run_staus}.",
+                                "message": f"The item run {self.item_run_id} has status {item_run_status}.",
                                 "run_id": self.item_run_id,
-                                "item_run_status": item_run_staus,
+                                "item_run_status": item_run_status,
                             }
                         )
                         return
@@ -88,7 +88,7 @@ class FabricTrigger(BaseTrigger):
                     self.log.info(
                         "Sleeping for %s. The pipeline state is %s.",
                         self.check_interval,
-                        item_run_staus,
+                        item_run_status,
                     )
                     await asyncio.sleep(self.check_interval)
                 except Exception as error:
@@ -106,7 +106,7 @@ class FabricTrigger(BaseTrigger):
             yield TriggerEvent(
                 {
                     "status": "error",
-                    "message": f"Timeout reached: The item run {self.item_run_id} has {item_run_staus}.",
+                    "message": f"Timeout reached: The item run {self.item_run_id} has {item_run_status}.",
                     "run_id": self.item_run_id,
                 }
             )

--- a/src/apache_airflow_microsoft_fabric_plugin/triggers/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/triggers/fabric.py
@@ -38,7 +38,7 @@ class FabricTrigger(BaseTrigger):
     def serialize(self):
         """Serialize the FabricTrigger instance."""
         return (
-            "airflow.providers.microsoft.powerbi.triggers.fabric.FabricTrigger",
+            "apache_airflow_microsoft_fabric_plugin.triggers.fabric.FabricTrigger",
             {
                 "fabric_conn_id": self.fabric_conn_id,
                 "item_run_id": self.item_run_id,


### PR DESCRIPTION
### Bug Fixes:
- Fix module import in trigger serialize
- Attempting to fetch item run details too soon after starting the job via API will return a 'NotFound' error. Added a retry mechanism until the API returns valid data.
- Fix variable name typo in trigger
- Set xcom run_status to the correct value on defer
- Remove duplicate function doc

### Improvements
- Authenticating with a client secret is now supported
- Added the ability to pass parameters to the fabric job
- Document additional features in README.md