### PR TITLE
The RunNotebook job throws a 'NotFound' error instead of 'RequestExecutionFailed'

### DIFF
--- a/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 import aiohttp
 import requests
 from asgiref.sync import sync_to_async
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
@@ -154,6 +155,7 @@ class FabricHook(BaseHook):
             "Authorization": f"Bearer {self._get_token()}",
         }
 
+    @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, max=10))
     def get_item_run_details(self, location: str) -> None:
         """
         Get details of the item run instance.
@@ -164,7 +166,10 @@ class FabricHook(BaseHook):
         response = self._send_request("GET", location, headers=headers)
 
         if response.ok:
-            return response.json()
+            item_run_details = response.json()
+            item_failure_reason = item_run_details.get("failureReason", dict())
+            if item_failure_reason is not None and item_failure_reason.get("errorCode") in ["RequestExecutionFailed", "NotFound"]:
+                raise FabricRunItemException("Unable to get item run details.")
         response.raise_for_status()
 
     def get_item_details(self, workspace_id: str, item_id: str) -> dict:

--- a/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
@@ -174,6 +174,7 @@ class FabricHook(BaseHook):
             item_failure_reason = item_run_details.get("failureReason", dict())
             if item_failure_reason is not None and item_failure_reason.get("errorCode") in ["RequestExecutionFailed", "NotFound"]:
                 raise FabricRunItemException("Unable to get item run details.")
+            return item_run_details
         response.raise_for_status()
 
     def get_item_details(self, workspace_id: str, item_id: str) -> dict:

--- a/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import time
 from typing import Any, Callable
-
 import aiohttp
 import requests
 from asgiref.sync import sync_to_async

--- a/src/apache_airflow_microsoft_fabric_plugin/operators/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/operators/fabric.py
@@ -136,7 +136,8 @@ class FabricRunItemOperator(BaseOperator):
             attempt += 1
             item_run_details_response = self.hook.get_item_run_details(self.location)
 
-            if item_run_details_response.get("failureReason", dict()) is not None and item_run_details_response.get("failureReason", dict()).get("errorCode") == "RequestExecutionFailed":
+            item_failure_reason = item_run_details_response.get("failureReason", dict())
+            if item_failure_reason is not None and item_failure_reason.get("errorCode") in ["RequestExecutionFailed", "NotFound"]:
                 self.log.info(f"Item run details not available yet. Retrying in {self.retry_delay} seconds...")
                 time.sleep(self.retry_delay)
             else:


### PR DESCRIPTION
When querying the API for a "Pipeline" job too quickly after the execute call, the endpoint throws a "RequestExecutionFailed" error. When querying the API for a "RunNotebook" job, it throws an explicit "NotFound" error. This adjusts the retry logic to handle both of these errors so Airflow won't wrongly assume a "RunNotebook" job failed.