### PR TITLE
Dynamic retry delay

### DIFF
--- a/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
+++ b/src/apache_airflow_microsoft_fabric_plugin/hooks/fabric.py
@@ -174,7 +174,7 @@ class FabricHook(BaseHook):
 
         @retry(
             stop=stop_after_attempt(self.max_retries),
-            wait=wait_exponential(multiplier=self.retry_delay / 2, max=10)
+            wait=wait_exponential(multiplier=1, min=self.retry_delay, max=10)
         )
         def _internal_get_item_run_details():
             headers = self.get_headers()


### PR DESCRIPTION
Apologies for not responding to your comments on the other PR last week. I think dynamic retry is something we should definitely keep, since we're catching an unintended error from Microsoft's side and there's no guarantee it will continue to fall in the hard-coded windows.

I'm setting `multiplier=self.retry_delay / 2` since the calculation is `multiplier * 2^x`, so we need to divide by 2 in order to set the retry delay to the parameter passed. This caused the resulting delay calculation to be `retry_delay * 2^(x-1)` which for attempt 1 will result in it being set to the retry delay and scaling based off of that.